### PR TITLE
Ranged comparisons and KeepOnlyColumns transformation

### DIFF
--- a/connectors/src/main/java/com/booking/validator/connectors/ActiveDataSourceConnections.java
+++ b/connectors/src/main/java/com/booking/validator/connectors/ActiveDataSourceConnections.java
@@ -47,6 +47,7 @@ public class ActiveDataSourceConnections {
 
     public void closeAll() {
         for(DataSourceConnection conn : connections.values()) { conn.close(); }
+        connections.clear();
     }
 
     public Map<String, DataSourceConnection> getConnections() {

--- a/connectors/src/main/java/com/booking/validator/connectors/constant/ConstantDataSourceConnection.java
+++ b/connectors/src/main/java/com/booking/validator/connectors/constant/ConstantDataSourceConnection.java
@@ -11,6 +11,7 @@ import java.util.Map;
  * Created by dbatheja on 07/02/20.
  */
 public class ConstantDataSourceConnection implements DataSourceConnection {
+
     public ConstantDataSourceConnection(Map<String, String> configuration) {
         // Doesn't need any connection
         // Data resides in Query Options

--- a/data/src/main/java/com/booking/validator/data/Data.java
+++ b/data/src/main/java/com/booking/validator/data/Data.java
@@ -1,5 +1,10 @@
 package com.booking.validator.data;
 
+import com.booking.validator.data.transformation.AliasColumnsTransformation;
+import org.apache.hadoop.yarn.webapp.hamlet.Hamlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -9,7 +14,9 @@ import java.util.stream.Collectors;
 public class Data {
 
     public static class Discrepancy {
-
+        static final Logger LOGGER = LoggerFactory.getLogger(Discrepancy.class);
+        private final static String ACCEPTABLE_DIFFERENCE_RANGES = "ranges"; // absolute difference between source and destination column to be in a certain range
+        private Map<String, Object> ranges;
         private static String columnDiff(String column, Object[] discrepancy){
 
             return String.format("%s=[%s,%s]", column,
@@ -23,7 +30,44 @@ public class Data {
         private final boolean isActualExists;
         private final boolean isExpectedExists;
 
-        private Discrepancy(Data expected, Data actual) {
+        private void initRanges(Map<String, Object> extra) {
+            ranges = extra != null ? (Map<String, Object>) extra.getOrDefault(ACCEPTABLE_DIFFERENCE_RANGES, null) : null;
+            ranges.entrySet().forEach(e->{
+                if (!(e.getValue() instanceof List || e.getValue() instanceof Number)) {
+                    LOGGER.warn("AcceptableDifference: each range should be a number or a list of 2 numbers");
+                    ranges.remove(e.getKey());
+                } else if (e.getValue() instanceof Number) {
+                    ArrayList<Double> l = new ArrayList<>();
+                    l.add(-Math.abs(((Number) e.getValue()).doubleValue()));
+                    l.add(Math.abs(((Number) e.getValue()).doubleValue()));
+                    ranges.put(e.getKey(), l);
+                } else if (e.getValue() instanceof List) {
+                    if (((List) e.getValue()).size() != 2) {
+                        LOGGER.warn("AcceptableDifference: each range should be a number or a list of 2 numbers");
+                        ranges.remove(e.getKey());
+                    }
+                }
+            });
+        }
+
+        public boolean isInRange(Object sourceValue, Object targetValue, List<Double> range) {
+            if (targetValue instanceof String || sourceValue instanceof String) {
+                LOGGER.warn("Ranged comparison can't be applied to string columns");
+                return false;
+            } else if (targetValue instanceof Number && sourceValue instanceof Number) {
+                Double doubleSourceValue = ((Number) sourceValue).doubleValue();
+                Double doubleTargetValue = ((Number) targetValue).doubleValue();
+                if (doubleTargetValue >= range.get(0)+doubleSourceValue && doubleTargetValue <= range.get(1)+doubleSourceValue) {
+                    return true;
+                }
+            } else {
+                LOGGER.warn("Ranged comparison can't compare values of non Number type.", targetValue);
+            }
+            return false;
+        }
+
+        private Discrepancy(Data expected, Data actual, Map<String, Object> extra) {
+            initRanges(extra);
             isExpectedExists = expected != null;
             isActualExists = actual != null;
             if (expected == null || actual == null) return;
@@ -35,11 +79,19 @@ public class Data {
 
             columnNames.stream()
                     .filter( k -> ! equalityTester.testEquality(expected.row.get(k), actual.row.get(k)) )
+                    .filter( k-> {
+                        if (ranges == null) {
+                            return true;
+                        } else if (ranges.containsKey(k)) {
+                            return !isInRange(expected.row.get(k), actual.row.get(k), (List<Double>) ranges.get(k));
+                        }
+                        return true;
+                    })
                     .forEach( k -> discrepancies.put(k, new Object[] {expected.row.get(k), actual.row.get(k)})
                     );
         }
 
-            public boolean hasDiscrepancy() {
+        public boolean hasDiscrepancy() {
             if (!isExpectedExists && !isActualExists) return false;
             if (isExpectedExists != isActualExists) return true;
 
@@ -61,8 +113,12 @@ public class Data {
 
     }
 
+    public static Discrepancy discrepancy(Data expected, Data actual, Map<String, Object> extra) {
+        return new Discrepancy(expected, actual, extra);
+    }
+
     public static Discrepancy discrepancy(Data expected, Data actual) {
-        return new Discrepancy(expected, actual);
+        return new Discrepancy(expected, actual, null);
     }
 
     private final Map<String, Object> row;

--- a/data/src/main/java/com/booking/validator/data/EqualityTester.java
+++ b/data/src/main/java/com/booking/validator/data/EqualityTester.java
@@ -2,10 +2,7 @@ package com.booking.validator.data;
 
 import org.apache.hadoop.hbase.shaded.org.apache.directory.api.util.Strings;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.BiFunction;
 
 /**

--- a/data/src/main/java/com/booking/validator/data/transformation/KeepColumnsTransformation.java
+++ b/data/src/main/java/com/booking/validator/data/transformation/KeepColumnsTransformation.java
@@ -1,0 +1,46 @@
+package com.booking.validator.data.transformation;
+
+import com.booking.validator.data.Data;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by dbatheja on 10/02/20.
+ */
+public class KeepColumnsTransformation implements Transformation {
+    static final Logger LOGGER = LoggerFactory.getLogger(IgnoreColumnsTransformation.class);
+    private static final KeepColumnsTransformation instance = new KeepColumnsTransformation();
+    private KeepColumnsTransformation(){}
+    public static KeepColumnsTransformation getInstance(){
+        return instance;
+    }
+
+    @Override
+    public Data apply(Data data, Object options) {
+        List<String> keepColumns;
+        if(options instanceof ArrayList) {
+            keepColumns = ((ArrayList<String>) options);
+        } else if (options instanceof String) {
+            keepColumns = new ArrayList<>();
+            keepColumns.add(options.toString());
+        } else {
+            keepColumns = new ArrayList<>();
+            LOGGER.warn("KeepColumns Transformation expects a list of Strings or a String");
+        }
+        Map<String, Object> row = data.getRow();
+        row.entrySet()
+           .removeIf(entry -> !keepColumns.contains(entry.getKey()));
+
+        return data;
+    }
+
+    @Override
+    public TransformationTypes getType() {
+        return TransformationTypes.KEEP_COLUMNS;
+    }
+}

--- a/data/src/main/java/com/booking/validator/data/transformation/TransformationFactory.java
+++ b/data/src/main/java/com/booking/validator/data/transformation/TransformationFactory.java
@@ -15,6 +15,7 @@ public class TransformationFactory {
     private static LinkedHashMap<TransformationTypes, Transformation> prioritizedTransformationMap =
             new LinkedHashMap<TransformationTypes, Transformation>(){{
         put(TransformationTypes.IGNORE_COLUMNS, IgnoreColumnsTransformation.getInstance());
+        put(TransformationTypes.KEEP_COLUMNS, KeepColumnsTransformation.getInstance());
         put(TransformationTypes.TIMESTAMPS_TO_EPOCHS, TimestampsToEpochsTransformation.getInstance());
         put(TransformationTypes.MAP_NULL_COLUMNS, MapNullColumnsTransformation.getInstance());
         put(TransformationTypes.ALIAS_COLUMNS, AliasColumnsTransformation.getInstance());

--- a/data/src/main/java/com/booking/validator/data/transformation/TransformationTypes.java
+++ b/data/src/main/java/com/booking/validator/data/transformation/TransformationTypes.java
@@ -5,6 +5,7 @@ package com.booking.validator.data.transformation;
  */
 public enum TransformationTypes {
     IGNORE_COLUMNS("ignore_columns"),
+    KEEP_COLUMNS("keep_columns"),
     ALIAS_COLUMNS("alias_columns"),
     MAP_NULL_COLUMNS("map_null_columns"),
     TIMESTAMPS_TO_EPOCHS("timestamps_to_epochs");

--- a/data/src/main/java/com/booking/validator/task/Task.java
+++ b/data/src/main/java/com/booking/validator/task/Task.java
@@ -2,12 +2,13 @@ package com.booking.validator.task;
 
 import com.booking.validator.data.Data;
 import com.booking.validator.data.source.DataSource;
+import com.booking.validator.task.extra.Extra;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import java.util.Map;
+import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -17,7 +18,7 @@ public class Task {
 
     private final String v="v1";
 
-    private Map<String, Object> extra;
+    private List<Extra> extra;
 
     private String tag;
 
@@ -35,7 +36,7 @@ public class Task {
     public Task(@JsonProperty("tag") String tag,
                 @JsonProperty("source") DataSource source,
                 @JsonProperty("target") DataSource target,
-                @JsonProperty("extra") Map<String, Object> extra) {
+                @JsonProperty("extra") List<Extra> extra) {
         this.source = requireNonNull(source);
         this.target = requireNonNull(target);
         this.tag = tag;
@@ -52,14 +53,13 @@ public class Task {
 
     public String toJson() throws RuntimeException {
         try {
-            String task = mapper.writeValueAsString(this);
-            return task;
+            return mapper.writeValueAsString(this);
         } catch (Exception e) {
             throw new RuntimeException("Failed to serialize task object to JSON string", e);
         }
     }
 
-    public Map<String, Object> getExtra() {
+    public List<Extra> getExtra() {
         return extra;
     }
 
@@ -90,7 +90,7 @@ public class Task {
         return triesCount - 1;
     }
 
-    public void setExtra(Map<String, Object> extra) {
+    public void setExtra(List<Extra> extra) {
         this.extra = extra;
     }
 

--- a/data/src/main/java/com/booking/validator/task/Task.java
+++ b/data/src/main/java/com/booking/validator/task/Task.java
@@ -47,7 +47,7 @@ public class Task {
 
     public TaskComparisonResult validate(Data sourceData, Data targetData) {
         triesCount ++;
-        return new TaskComparisonResult(this, Data.discrepancy(sourceData, targetData), null);
+        return new TaskComparisonResult(this, Data.discrepancy(sourceData, targetData, this.extra), null);
     }
 
     public String toJson() throws RuntimeException {

--- a/data/src/main/java/com/booking/validator/task/extra/AcceptableRanges.java
+++ b/data/src/main/java/com/booking/validator/task/extra/AcceptableRanges.java
@@ -1,0 +1,63 @@
+package com.booking.validator.task.extra;
+
+import com.booking.validator.data.Data;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.htrace.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by dbatheja on 03/03/20.
+ */
+public class AcceptableRanges extends Extra {
+    private Map<String, List<Double>> ranges;
+    static final Logger LOGGER = LoggerFactory.getLogger(Data.Discrepancy.class);
+
+    @JsonCreator
+    public AcceptableRanges() {
+        super(ExtraTypes.ACCEPTABLE_RANGE_DIFFERENCES.getValue());
+        ranges = new HashMap<>();
+    }
+
+    public AcceptableRanges add(String key, double s, double e) {
+        if (s>0 || e < s) {
+            LOGGER.warn("Acceptable ranges: s should be a negative number\n TIP: target is checked from [source + s, source + e]");
+            return this;
+        }
+        if (!ranges.containsKey(key)) {
+            ranges.put(key, new ArrayList<Double>(){{
+                add(s);
+                add(e);
+            }});
+        } else {
+            LOGGER.warn("key:"+key+" already added to acceptable ranges Map");
+        }
+        return this;
+    }
+    public AcceptableRanges add(String key, double s) {
+        if (!ranges.containsKey(key)) {
+            ranges.put(key, new ArrayList<Double>(){{
+                add(-Math.abs(s));
+                add(Math.abs(s));
+            }});
+        } else {
+            LOGGER.warn("key:"+key+" already added to acceptable ranges Map");
+        }
+        return this;
+    }
+
+    @JsonProperty("ranges")
+    public Map<String, List<Double>> getRanges() {
+        return ranges;
+    }
+
+    public void setRanges(Map<String, List<Double>> ranges) {
+        this.ranges = ranges;
+    }
+}
+

--- a/data/src/main/java/com/booking/validator/task/extra/Extra.java
+++ b/data/src/main/java/com/booking/validator/task/extra/Extra.java
@@ -1,0 +1,39 @@
+package com.booking.validator.task.extra;
+import com.fasterxml.jackson.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by dbatheja on 03/03/20.
+ */
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AcceptableRanges.class, name = ExtraTypes.Constants.ACCEPTABLE_RANGE_DIFFERENCES),
+        @JsonSubTypes.Type(value = NestedComparisons.class, name = ExtraTypes.Constants.CHECK_NESTED_FIELDS),
+})
+public abstract class Extra {
+
+    private String type;
+
+    @JsonCreator
+    public Extra(@JsonProperty("type") String type) {
+        this.type = type;
+    }
+
+    @JsonIgnore
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public static List<Extra> builder() {
+        return new ArrayList<>();
+    }
+}

--- a/data/src/main/java/com/booking/validator/task/extra/ExtraTypes.java
+++ b/data/src/main/java/com/booking/validator/task/extra/ExtraTypes.java
@@ -1,0 +1,35 @@
+package com.booking.validator.task.extra;
+
+/**
+ * Created by dbatheja on 07/02/20.
+ */
+public enum ExtraTypes {
+
+    ACCEPTABLE_RANGE_DIFFERENCES(Constants.ACCEPTABLE_RANGE_DIFFERENCES),
+    CHECK_NESTED_FIELDS(Constants.CHECK_NESTED_FIELDS);
+
+    public interface Constants {
+        String ACCEPTABLE_RANGE_DIFFERENCES = "ranges";
+        String CHECK_NESTED_FIELDS = "nested_checks";
+    }
+
+    private String value;
+
+    ExtraTypes(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static ExtraTypes fromString(String text) {
+        for (ExtraTypes b : ExtraTypes.values()) {
+            if (b.getValue().equalsIgnoreCase(text)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}
+

--- a/data/src/main/java/com/booking/validator/task/extra/NestedComparisons.java
+++ b/data/src/main/java/com/booking/validator/task/extra/NestedComparisons.java
@@ -1,0 +1,25 @@
+package com.booking.validator.task.extra;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by dbatheja on 03/03/20.
+ */
+public class NestedComparisons extends Extra {
+    private boolean enabled;
+
+    @JsonCreator
+    public NestedComparisons(@JsonProperty("enabled") boolean enabled) {
+        super(ExtraTypes.Constants.CHECK_NESTED_FIELDS);
+        this.enabled = enabled;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/service/src/test/java/TestTransformations.java
+++ b/service/src/test/java/TestTransformations.java
@@ -6,12 +6,15 @@ import com.booking.validator.data.transformation.TransformationTypes;
 import com.booking.validator.service.supplier.data.source.QueryConnectorsForTask;
 import com.booking.validator.task.Task;
 import com.booking.validator.task.TaskComparisonResult;
+import com.booking.validator.task.extra.AcceptableRanges;
+import com.booking.validator.task.extra.Extra;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class TestTransformations {
@@ -57,7 +60,11 @@ public class TestTransformations {
         Task taskV1 = new Task("unit_test", dataSource, dataSource2, null);
         System.out.println(taskV1.toJson());
         ActiveDataSourceConnections.getInstance().add("constantSource", Types.CONSTANT.getValue(), null);
-        QueryConnectorsForTask qcft = new QueryConnectorsForTask(taskV1);
+
+        ObjectMapper mapper = new ObjectMapper();
+        Task taskDeserialized = mapper.readValue(taskV1.toJson(), Task.class);
+
+        QueryConnectorsForTask qcft = new QueryConnectorsForTask(taskDeserialized);
         TaskComparisonResult taskComparisonResult = qcft.get().get();
         assertTrue(taskComparisonResult.isOk());
 
@@ -79,14 +86,19 @@ public class TestTransformations {
         DataSource dataSource2 = new DataSource(
                 "constantSource",
                 new ConstantQueryOptions("constant", (Map<String, Object>)data2, null));
-        Task taskV1 = new Task("unit_test", dataSource, dataSource2, new HashMap<String, Object>(){{
-            put("ranges", new HashMap<String, Object>(){{
-                put("b", 2);
-            }});
-        }});
+        List<Extra> extraList = Extra.builder();
+        extraList.add(new AcceptableRanges()
+                    .add("b", 3.0)
+                    .add("c", 4));
+        Task taskV1 = new Task("unit_test", dataSource, dataSource2, extraList);
+
         System.out.println(taskV1.toJson());
         ActiveDataSourceConnections.getInstance().add("constantSource", Types.CONSTANT.getValue(), null);
-        QueryConnectorsForTask qcft = new QueryConnectorsForTask(taskV1);
+
+        ObjectMapper mapper = new ObjectMapper();
+        Task taskDeserialized = mapper.readValue(taskV1.toJson(), Task.class);
+
+        QueryConnectorsForTask qcft = new QueryConnectorsForTask(taskDeserialized);
         TaskComparisonResult taskComparisonResult = qcft.get().get();
 
         assertTrue(taskComparisonResult.isOk());


### PR DESCRIPTION
This pull request adds support for:
- **Ranged comparisons** (Difference between source and destination can be acceptable in a specified range (don't flag it))
- **KeepOnlyColumns** transformation: Check only the given columns from a given data source (ignore the rest).
:robot: